### PR TITLE
Add pixel shader dumping/override

### DIFF
--- a/DATA/DSfix.ini
+++ b/DATA/DSfix.ini
@@ -198,6 +198,19 @@ enableTextureOverride 0
 enableTexturePrefetch 0
 
 ###############################################################################
+# Shader Override Options
+###############################################################################
+
+# Enable pixel shader dumping
+# Disassembled pixel shaders will be dumped to "dsfix\pixelshader_dump\[hash].asm".
+enablePixelShaderDumping 0
+
+# Enable pixel shader override
+# Pixel shaders named "dsfix\pixelshader_override\[hash].asm" will
+# replace the corresponding originals.
+enablePixelShaderOverride 0
+
+###############################################################################
 # Other Options
 ###############################################################################
 

--- a/RenderstateManager.h
+++ b/RenderstateManager.h
@@ -113,6 +113,10 @@ class RSManager {
     
     std::map<UINT32, MemData> cachedTexFiles;
 
+	bool disassemblePixelShader(CONST DWORD *pFunction, LPD3DXBUFFER *ppBuffer);
+	void dumpPixelShader(UINT32 hash, LPD3DXBUFFER pBuffer);
+	bool getOverridePixelShader(UINT32 hash, LPD3DXBUFFER *ppBuffer);
+
 private:
     ~RSManager();
 
@@ -189,4 +193,5 @@ public:
 	HRESULT redirectD3DXCreateTextureFromFileInMemoryEx(LPDIRECT3DDEVICE9 pDevice, LPCVOID pSrcData, UINT SrcDataSize, UINT Width, UINT Height, UINT MipLevels, DWORD Usage, D3DFORMAT Format, D3DPOOL Pool, DWORD Filter, DWORD MipFilter, D3DCOLOR ColorKey, D3DXIMAGE_INFO* pSrcInfo, PALETTEENTRY* pPalette, LPDIRECT3DTEXTURE9* ppTexture);
 	HRESULT redirectSetTextureStageState(DWORD Stage, D3DTEXTURESTAGESTATETYPE Type, DWORD Value);
 	HRESULT redirectSetRenderState(D3DRENDERSTATETYPE State, DWORD Value);
+	HRESULT redirectCreatePixelShader(CONST DWORD *pfunction, IDirect3DPixelShader9 **ppShader);
 };

--- a/Settings.def
+++ b/Settings.def
@@ -52,6 +52,10 @@ SETTING(bool, EnableTextureDumping, "enableTextureDumping", false);
 SETTING(bool, EnableTextureOverride, "enableTextureOverride", false);
 SETTING(bool, EnableTexturePrefetch, "enableTexturePrefetch", false);
 
+// Pixel Shader Override Options
+SETTING(bool, EnablePixelShaderDumping, "enablePixelShaderDumping", false);
+SETTING(bool, EnablePixelShaderOverride, "enablePixelShaderOverride", false);
+
 // HUD options
 SETTING(bool, EnableHudMod, "enableHudMod", false)
 SETTING(bool, EnableMinimalHud, "enableMinimalHud", false)

--- a/d3d9dev.cpp
+++ b/d3d9dev.cpp
@@ -182,14 +182,7 @@ HRESULT APIENTRY hkIDirect3DDevice9::CreateOffscreenPlainSurface(UINT Width, UIN
 }
 
 HRESULT APIENTRY hkIDirect3DDevice9::CreatePixelShader(CONST DWORD* pFunction,IDirect3DPixelShader9** ppShader) {
-	HRESULT res = m_pD3Ddev->CreatePixelShader(pFunction, ppShader);
-	if(Settings::get().getLogLevel() > 12) {
-		SDLOG(12, "CreatePixelShader data: %p : shader: %p\n", pFunction, *ppShader);
-		LPD3DXBUFFER buffer;
-		D3DXDisassembleShader(pFunction, false, NULL, &buffer);
-		SDLOG(12, "===== disassembly:\n%s\n==============\n", buffer->GetBufferPointer());
-	}
-	return res;
+	return RSManager::get().redirectCreatePixelShader(pFunction, ppShader);
 }
 
 HRESULT APIENTRY hkIDirect3DDevice9::CreateQuery(D3DQUERYTYPE Type,IDirect3DQuery9** ppQuery) {

--- a/main.cpp
+++ b/main.cpp
@@ -135,3 +135,37 @@ void errorExit(LPTSTR lpszFunction) {
 bool fileExists(const char *filename) {
   return std::ifstream(filename).good();
 }
+
+bool writeFile(const char *filename, const char *data, size_t length) {
+	std::ofstream file(filename, std::ios::out | std::ios::binary);
+	if (!file) {
+		SDLOG(0, "Failed to open %s: %s\n", filename, strError(errno));
+		return false;
+	}
+	file.write(data, length);
+	if (!file) {
+		SDLOG(0, "Failed to write to %s: %s\n", filename, strError(errno));
+		return false;
+	}
+	file.close();
+	if (!file) {
+		SDLOG(0, "Failed to close %s: %s\n", filename, strError(errno));
+		return false;
+	}
+	return true;
+}
+
+std::string formatMessage(DWORD messageId) {
+	char *buffer = nullptr;
+	size_t length = FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+		nullptr, messageId, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPTSTR)&buffer, 0, nullptr);
+	std::string result(buffer, length);
+	LocalFree(buffer);
+	return result;
+}
+
+std::string strError(int err) {
+	std::string result(4096, '\0');
+	strerror_s(&result[0], result.length(), err);
+	return result;
+}

--- a/main.h
+++ b/main.h
@@ -34,9 +34,13 @@
 
 #include "d3d9.h"
 #include "dinput.h"
+#include <string>
 
 char *GetDirectoryFile(char *filename);
 bool fileExists(const char *filename);
+bool writeFile(const char *filename, const char *data, size_t length);
+std::string formatMessage(DWORD messageId);
+std::string strError(int err);
 void __cdecl sdlogtime();
 void __cdecl sdlog(const char * fmt, ...);
 void errorExit(LPTSTR lpszFunction);


### PR DESCRIPTION
This change adds configurable dumping and overriding of pixel shaders as
assembler, similar to the texuture dumping and overriding.