### PR TITLE
Update water surface blockiness fix

### DIFF
--- a/d3d9dev.cpp
+++ b/d3d9dev.cpp
@@ -590,12 +590,14 @@ HRESULT APIENTRY hkIDirect3DDevice9::SetPixelShaderConstantF(UINT StartRegister,
 			size_t bufferSize = sizeof(float) * 4 * Vector4fCount;
 			float* pBuffer = static_cast<float*>(alloca(bufferSize));
 			memcpy_s(pBuffer, bufferSize, pConstantData, bufferSize);
-			float halfWidth = Settings::get().getRenderWidth() / 2.f;
-			float halfHeight = Settings::get().getRenderHeight() / 2.f;
-			pBuffer[offset] = halfWidth;
-			pBuffer[offset + 1] = halfHeight;
-			pBuffer[offset + 2] = 1 / halfWidth;
-			pBuffer[offset + 3] = 1 / halfHeight;
+
+			UINT width;
+			UINT height;
+			getDofRes(HALF_X_RESOLUTION, HALF_Y_RESOLUTION, width, height);
+			pBuffer[offset] = static_cast<float>(width);
+			pBuffer[offset + 1] = static_cast<float>(height);
+			pBuffer[offset + 2] = 1.f / width;
+			pBuffer[offset + 3] = 1.f / height;
 
 			return m_pD3Ddev->SetPixelShaderConstantF(StartRegister, pBuffer, Vector4fCount);
 		}


### PR DESCRIPTION
The water surface is rendered into a buffer that has the same resolution
as the first DoF buffer, and the values passed in c164 now reflect this.

The dithering effect is not actually used by the unmodified game, and
values passed through c164 should match the exact resolution of the
render buffer used for the water surface. This is also required if the
water surface is to look good in all choices of DoF buffer resolution.