### PR TITLE
Make AA work also when FPS unlocking is disabled

### DIFF
--- a/FPS.cpp
+++ b/FPS.cpp
@@ -187,11 +187,6 @@ void applyFPSPatch() {
 		return;
 	}
 
-	// Init counter for frame-rate calculations
-	lastRenderTime = 0.0f;
-	QueryPerformanceFrequency(&timerFreq);
-	QueryPerformanceCounter(&counterAtStart);
-
 	// Binary patches
 	//--------------------------------------------------------------
 	DWORD address;
@@ -207,4 +202,11 @@ void applyFPSPatch() {
 	DetourApply((BYTE*)address, (BYTE*)getDrawThreadMsgCommand, 5, CALLOP);
 		
 	SDLOG(0, "FPS unlocked\n");
+}
+
+void initFPSTimer() {
+	// Init counter for frame-rate calculations
+	lastRenderTime = 0.0f;
+	QueryPerformanceFrequency(&timerFreq);
+	QueryPerformanceCounter(&counterAtStart);
 }

--- a/FPS.h
+++ b/FPS.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+void initFPSTimer();
 void applyFPSPatch();
 
 // returns time since startup in milliseconds

--- a/RenderstateManager.cpp
+++ b/RenderstateManager.cpp
@@ -870,6 +870,6 @@ void RSManager::frameTimeManagement() {
 			SwitchToThread();
 			renderTime = getElapsedTime() - lastPresentTime;
 		}
-		lastPresentTime = getElapsedTime();
 	}
+	lastPresentTime = getElapsedTime();
 }

--- a/main.cpp
+++ b/main.cpp
@@ -66,6 +66,7 @@ bool WINAPI DllMain(HMODULE hDll, DWORD dwReason, PVOID pvReserved) {
 
 		earlyDetour();
 
+		initFPSTimer();
 		if(Settings::get().getUnlockFPS()) applyFPSPatch();
 
 		return true;


### PR DESCRIPTION
Frame time calculations would not be properly initialized or updated
unless FPS unlocking was enabled. This would cause the minimum FPS
handling to keep anti-aliasing disabled all the time.

This change makes frame time calculations and anti-aliasing work wether
FPS unlocking is enabled or not.