### PR TITLE
Make intro skipping work without FPS unlocking

### DIFF
--- a/Detouring.cpp
+++ b/Detouring.cpp
@@ -31,7 +31,7 @@ BOOL WINAPI DetouredQueryPerformanceCounter(_Out_ LARGE_INTEGER *lpPerformanceCo
 	int captured = CaptureStackBackTrace(0, 128, traces, &hash);
 	SDLOG(14, "T %6lu: Detouring: QueryPerformanceCounter, stack depth %3d, hash %20ul\n", GetCurrentThreadId(), captured, hash);
 	BOOL ret = TrueQueryPerformanceCounter(lpPerformanceCount);
-	if(timingIntroMode && captured == 1) {
+	if(timingIntroMode && captured < 3) {
 		perfCountIncrease.QuadPart += countsPerSec.QuadPart/50;
 	}
 	lpPerformanceCount->QuadPart += perfCountIncrease.QuadPart;


### PR DESCRIPTION
When FPS unlocking is disabled, intro skipping depends a wrapper for
QueryPerformanceCounter which artificially speeds up time. A criteria
for the modified behaviour to trigger is that the call stack depth for
the QueryPerformanceCounter call is 1.

At least for the Steam version of DS with exe version 1.0.2.0, the call
stack depth for the relevant call is 2. With intro skipping enabled but
FPS unlocking disabled, this would cause the logos to not appear, since
the Present calls are never made, but there would be a long delay with a
black screen when the logos would usually show.

This change triggers the modified QueryPerformanceCounter behaviour if
the stack depth is either 1 or 2. This makes intro skipping work on this
DS version also with FPS unlocking disabled.