### PR TITLE
Make SMAA trace macros work also without UNICODE

### DIFF
--- a/SMAA.cpp
+++ b/SMAA.cpp
@@ -46,14 +46,19 @@ using namespace std;
 
 #include "Settings.h"
 
+#ifdef UNICODE
+#define STRINGIFY(x) L#x
+#else
+#define STRINGIFY(x) #x
+#endif
 
 #pragma region Useful Macros from DXUT (copy-pasted here as we prefer this to be as self-contained as possible)
 #if defined(DEBUG) || defined(_DEBUG)
 #ifndef V
-#define V(x) { hr = (x); if (FAILED(hr)) { DXTrace(__FILE__, (DWORD)__LINE__, hr, L#x, true); } }
+#define V(x) { hr = (x); if (FAILED(hr)) { DXTrace(__FILE__, (DWORD)__LINE__, hr, STRINGIFY(x), true); } }
 #endif
 #ifndef V_RETURN
-#define V_RETURN(x) { hr = (x); if (FAILED(hr)) { return DXTrace(__FILE__, (DWORD)__LINE__, hr, L#x, true); } }
+#define V_RETURN(x) { hr = (x); if (FAILED(hr)) { return DXTrace(__FILE__, (DWORD)__LINE__, hr, STRINGIFY(x), true); } }
 #endif
 #else
 #ifndef V


### PR DESCRIPTION
The V and V_RETURN macros in SMAA.cpp call DXTrace whose implementation
and fourth argument type depends on wether UNICODE is defined during the
build. The macros as written assume that UNICODE is defined.

This change makes the macro work wether UNICODE is defined or not.